### PR TITLE
Updated insecure link to a secure context

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin is available via Plugin Manager: use Plugins > Plugin Manager > Show
 ### Manual installation
 
 1. Install Python Script plugin (available in Plugin Manager).
-2. [Download EmmetNPP](http://download.emmet.io/npp/emmet-npp.zip) plugin and unpack it into `C:\Program Files\Notepad++\plugins` folder
+2. [Download EmmetNPP](https://download.emmet.io/npp/emmet-npp.zip) plugin and unpack it into `C:\Program Files\Notepad++\plugins` folder
 3. Start Nodepad++. You should see `Plugins > Emmet` menu item.
 
 ## Changing keyboard shortcuts


### PR DESCRIPTION
Fixed link to download link pointing to "Download EmmetNPP". The link provided originally is served over `http`, and the browser blocks all unsecure links over secure connections, with the error logging to the console as `Mixed Content`. To learn more check this [chromium blog](https://blog.chromium.org/2020/02/protecting-users-from-insecure.html)